### PR TITLE
center the Video from video.js in the player view

### DIFF
--- a/lecture2gether-vue/src/components/Player.vue
+++ b/lecture2gether-vue/src/components/Player.vue
@@ -75,7 +75,7 @@ export default class L2gPlayer extends Vue {
                 // videojs options
                 muted: true,
                 language: 'en',
-                height: '500px',
+                width: '750px',
                 playbackRates: [0.7, 1.0, 1.3, 1.5, 2.0],
                 sources: [{
                     type,

--- a/lecture2gether-vue/src/views/Room.vue
+++ b/lecture2gether-vue/src/views/Room.vue
@@ -1,5 +1,5 @@
 <template>
-    <l2g-player url="https://www.youtube.com/watch?v=m8UQ4O7UiDs"></l2g-player>
+    <l2g-player class="l2g-player" url="https://www.youtube.com/watch?v=m8UQ4O7UiDs"></l2g-player>
 </template>
 
 <script lang="ts">
@@ -43,4 +43,14 @@ export default class L2gPlayerView extends Vue {
 </script>
 
 <style scoped lang="scss">
+    .l2g-player > * {
+        width: 100%!important;
+    }
+    .l2g-player {
+        margin: auto;
+        //hacky way to force centered video.
+        //this size has to be the same as the video
+        //width in src/components/Player.vue
+        max-width: 750px;
+    }
 </style>


### PR DESCRIPTION
This is a quick but hacky way to center the video. The max-width of the player and the video width have to match up tho.