### PR TITLE
Reset room user count on restart

### DIFF
--- a/lecture2gether_flask/app.py
+++ b/lecture2gether_flask/app.py
@@ -60,6 +60,13 @@ while True:
         logging.info("SUCCESS: Connected to Redis database.")
         break
 
+# Kick dead sessions (cause socket.io reloaded) out of rooms
+for room_token, room in db.hgetall('rooms').items():  # For all rooms in db
+    room = json.loads(room) # Deserialize room data
+    room['count'] = 0 # Set connections to 0 because no body can be connected
+    db.hset('rooms', room_token, json.dumps(room))
+    logging.info("Kick dead sessions out of room {}".format(room_token))
+
 # Create cleanup deamon, that deletes abandoned rooms from the database
 # Get params
 cleanup_interval = int(os.getenv('CLEANUP_INTERVAL', 60*15))


### PR DESCRIPTION
Reset the room user count for all existing rooms in the db if the backend is started. This is done because all socket.io sessions are disconnected if the server restarts. If the server is killed some clients are still marked as connected in the db, this needs to be cleaned before the server starts. The connection count is otherwise off by a few connections if the server restarts and the clients reconnect to the same room.