### PR TITLE
Fix: Leave room before db access

### DIFF
--- a/lecture2gether_flask/app.py
+++ b/lecture2gether_flask/app.py
@@ -227,6 +227,7 @@ def on_leave(data):
     if not room_token in rooms(sid=request.sid):
         return {'status_code': 403}, 403
 
+    leave_room(room_token)
     # Get room from db
     room = json.loads(db.hget('rooms', room_token))
     # Deacrease active users in room
@@ -235,8 +236,7 @@ def on_leave(data):
     emit('room_user_count_update', {"users": room['count']}, room=room_token)
     # Save in db
     db.hset('rooms', room_token, json.dumps(room))
-    # Leave the socket.io room
-    leave_room(room_token)
+    
     # Return status
     return {'status_code': 200}, 200
 

--- a/lecture2gether_flask/app.py
+++ b/lecture2gether_flask/app.py
@@ -227,6 +227,7 @@ def on_leave(data):
     if not room_token in rooms(sid=request.sid):
         return {'status_code': 403}, 403
 
+    # Leave the socket.io room
     leave_room(room_token)
     # Get room from db
     room = json.loads(db.hget('rooms', room_token))


### PR DESCRIPTION
Fix: The room counter is decremented before the user left the room. 

Explanation: Under some circumstances, there are two room count decrements. One in the `leave` event and one in the `disconnect` event. This happens because the disconnect removes the user from all its rooms while it is asynchronously removed by the `leave` call of the client. This can be fixed by leaving the room before decrementing the counter, so the disconnect does not iterate over the room while it is accessed by the db and leaves it to.

Closes: #62 