### PR TITLE
Add faster playback rate

### DIFF
--- a/lecture2gether-vue/src/components/Player.vue
+++ b/lecture2gether-vue/src/components/Player.vue
@@ -95,7 +95,7 @@ export default class L2gPlayer extends Vue {
 
     getPlaybackRatesFromSource(src: string): Number[] {
         if (src === 'video/youtube') {
-            // YouTube does not support 4x player speed
+            // YouTube does not support player speed above 2x
             return [0.75, 1.0, 1.25, 1.5, 1.75, 2.0];
         } else {
             return [0.75, 1.0, 1.25, 1.5, 1.75, 2.0, 2.5];

--- a/lecture2gether-vue/src/components/Player.vue
+++ b/lecture2gether-vue/src/components/Player.vue
@@ -77,7 +77,7 @@ export default class L2gPlayer extends Vue {
             muted: false,
             language: 'en',
             width: '750px',
-            playbackRates: [0.75, 1.0, 1.25, 1.5, 1.75, 2.0],
+            playbackRates: [0.75, 1.0, 1.25, 1.5, 1.75, 2.0, 4.0],
             sources,
             techOrder: ['youtube', 'html5'],
             youtube: {

--- a/lecture2gether-vue/src/components/Player.vue
+++ b/lecture2gether-vue/src/components/Player.vue
@@ -64,9 +64,11 @@ export default class L2gPlayer extends Vue {
     }
 
     get playerOptions() {
-        const sources = [];
+        let source;
+        let playbackRates;
         try {
-            sources.push(this.getSourceFromURL(this.url));
+            source = this.getSourceFromURL(this.url);
+            playbackRates = this.getPlaybackRatesFromSource(source.type);
         } catch (e) {
             console.error(e);
             // Show error page
@@ -77,8 +79,8 @@ export default class L2gPlayer extends Vue {
             muted: false,
             language: 'en',
             width: '750px',
-            playbackRates: [0.75, 1.0, 1.25, 1.5, 1.75, 2.0, 4.0],
-            sources,
+            playbackRates,
+            sources: [source],
             techOrder: ['youtube', 'html5'],
             youtube: {
                 ytControls: 0,
@@ -89,6 +91,15 @@ export default class L2gPlayer extends Vue {
     get player(): videojs.Player {
         // @ts-ignore
         return this.$refs.videoPlayer.player;
+    }
+
+    getPlaybackRatesFromSource(src: string): Number[] {
+        if (src === 'video/youtube') {
+            // YouTube does not support 4x player speed
+            return [0.75, 1.0, 1.25, 1.5, 1.75, 2.0];
+        } else {
+            return [0.75, 1.0, 1.25, 1.5, 1.75, 2.0, 2.5];
+        }
     }
 
     getSourceFromURL(url: string): {type: string; src: string} {
@@ -261,5 +272,8 @@ export default class L2gPlayer extends Vue {
 }
 .video-js .vjs-duration {
     display: block;
+}
+.vjs-menu-button-popup .vjs-menu .vjs-menu-content {
+    max-height: 16em;
 }
 </style>


### PR DESCRIPTION
Adds a playback rate of 4x as requested in the issue #78. In my tests, speeds with more than 4x had no sound therefore this seems to be the maximum.

Closes #78 