### PR TITLE
Fix metadata layout

### DIFF
--- a/lecture2gether-vue/src/components/VideoMetaData.vue
+++ b/lecture2gether-vue/src/components/VideoMetaData.vue
@@ -28,10 +28,15 @@
         <v-spacer></v-spacer>
         <a class="license body-1 meta-data-link"
            :href="videoMetaData.licenseLink"
-           v-if="videoMetaData.license !== null"
+           v-if="videoMetaData.license !== null && videoMetaData.licenseLink !== null"
         >
             License: {{ videoMetaData.license }}
         </a>
+        <span class="license body-1"
+           v-if="videoMetaData.license !== null && videoMetaData.licenseLink === null"
+        >
+            License: {{ videoMetaData.license }}
+        </span>
     </div>
 </template>
 

--- a/lecture2gether-vue/src/components/VideoMetaData.vue
+++ b/lecture2gether-vue/src/components/VideoMetaData.vue
@@ -26,17 +26,19 @@
             </div>
         </div>
         <v-spacer></v-spacer>
-        <a class="license body-1 meta-data-link"
-           :href="videoMetaData.licenseLink"
-           v-if="videoMetaData.license !== null && videoMetaData.licenseLink !== null"
-        >
-            License: {{ videoMetaData.license }}
-        </a>
-        <span class="license body-1"
-           v-if="videoMetaData.license !== null && videoMetaData.licenseLink === null"
-        >
-            License: {{ videoMetaData.license }}
-        </span>
+        <div>
+            <a class="license body-1 meta-data-link"
+            :href="videoMetaData.licenseLink"
+            v-if="videoMetaData.license !== null && videoMetaData.licenseLink !== null"
+            >
+                License: {{ videoMetaData.license }}
+            </a>
+            <span class="license body-1"
+            v-if="videoMetaData.license !== null && videoMetaData.licenseLink === null"
+            >
+                License: {{ videoMetaData.license }}
+            </span>
+        </div>
     </div>
 </template>
 

--- a/lecture2gether-vue/src/components/VideoMetaData.vue
+++ b/lecture2gether-vue/src/components/VideoMetaData.vue
@@ -26,15 +26,16 @@
             </div>
         </div>
         <v-spacer></v-spacer>
-        <div>
+        <div
+        v-if="videoMetaData.license !== null">
             <a class="license body-1 meta-data-link"
             :href="videoMetaData.licenseLink"
-            v-if="videoMetaData.license !== null && videoMetaData.licenseLink !== null"
+            v-if="videoMetaData.licenseLink !== null"
             >
                 License: {{ videoMetaData.license }}
             </a>
             <span class="license body-1"
-            v-if="videoMetaData.license !== null && videoMetaData.licenseLink === null"
+            v-if="videoMetaData.licenseLink === null"
             >
                 License: {{ videoMetaData.license }}
             </span>


### PR DESCRIPTION
This PR fixes a small frontend issue with displaying the license metadata.

TODO:

- [x] Fix height of license box
- [X] Check overflow of long title and handle this (e.g. by decreasing font size)
  -  I think it's okay as is