### PR TITLE
make initial loading faster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 .venvs
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,8 +66,8 @@ COPY --from=frontend /app/src/frontend/dist/ /app/static
 # Setup configs
 VOLUME /app/config
 ADD docker/supervisor.conf /etc/supervisor/conf.d/app.conf
-ADD docker/settings.json /app/config/settings.json
-RUN ln -sf /app/config/settings.json /app/static/settings.json
+ADD docker/settings.js /app/config/settings.js
+RUN ln -sf /app/config/settings.js /app/static/settings.js
 ADD docker/nginx.conf /etc/nginx/sites-enabled/default
 
 # http

--- a/README.md
+++ b/README.md
@@ -127,9 +127,13 @@ SENTRY\_ENV | default | Sentry [environment](https://docs.sentry.io/error-report
 
 [1] This key is **publicly readable**, restrict its usage to the used website (e.g. https://lecture2gether.eu or equivalent IP address) and Google Drive in the Google API console.
 
-The frontend is configured via a `settings.json` file which should be reachable on a
-request to `/settings.json` from the running browser application.
-The format is as follows:
+The frontend is configured via a `settings.js` file which should be reachable on a
+request to `/settings.js` from the running browser application.
+This Javascript file **must** register the variable `window.L2GO_SETTINGS` which **must** be an object defining the
+below described properties.
+It can be mounted into our provided container under `/app/config/settings.js`.
+
+The frontend settings object is defined as follows:
 ```
 {
     "apiRoot": <string>,        // Under which url the server is reachable for http api calls

--- a/docker/settings.js
+++ b/docker/settings.js
@@ -1,0 +1,6 @@
+window.L2GO_SETTINGS = {
+    apiRoot: '/api/',
+    socketioHost: '',
+    environment: 'dev',
+    setry_dsn: '',
+};

--- a/docker/settings.json
+++ b/docker/settings.json
@@ -1,6 +1,0 @@
-{
-  "apiRoot": "/api/",
-  "socketioHost": "",
-  "environment": "",
-  "sentry_dsn": ""
-}

--- a/kustomization.yml
+++ b/kustomization.yml
@@ -11,4 +11,4 @@ configMapGenerator:
   - name: "backend"
   - name: "frontend"
     files:
-      - "settings.json=./docker/settings.json"
+      - "settings.js=./docker/settings.js"

--- a/lecture2gether-vue/.gitignore
+++ b/lecture2gether-vue/.gitignore
@@ -12,7 +12,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Editor directories and files
-.idea
 .vscode
 *.suo
 *.ntvs*

--- a/lecture2gether-vue/public/index.html
+++ b/lecture2gether-vue/public/index.html
@@ -19,6 +19,7 @@
     </strong>
 </noscript>
 <div id="app"></div>
+<script src="/settings.js"></script>
 <!-- built files will be auto injected -->
 </body>
 </html>

--- a/lecture2gether-vue/public/settings.js
+++ b/lecture2gether-vue/public/settings.js
@@ -1,0 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+window.L2GO_SETTINGS = {
+    apiRoot: 'http://localhost:5000/api',
+    socketioHost: 'http://localhost:5000',
+    environment: 'dev',
+};

--- a/lecture2gether-vue/public/settings.json
+++ b/lecture2gether-vue/public/settings.json
@@ -1,5 +1,0 @@
-{
-  "apiRoot": "http://localhost:5000/api/",
-  "socketioHost": "http://localhost:5000",
-  "environment": "dev"
-}

--- a/lecture2gether-vue/src/App.vue
+++ b/lecture2gether-vue/src/App.vue
@@ -20,10 +20,7 @@ import Lecture2GetherFooter from '@/components/Lecture2GetherFooter.vue';
 })
 export default class App extends Vue {
     created(): void {
-        this.$store.dispatch('fetchSettings')
-            .then(() => {
-                connect(this.$store);
-            });
+        connect(this.$store)
         window.addEventListener('beforeunload', this.onClose);
     }
 

--- a/lecture2gether-vue/src/main.ts
+++ b/lecture2gether-vue/src/main.ts
@@ -5,32 +5,30 @@ import store from './plugins/store';
 import vuetify from './plugins/vuetify';
 import * as Sentry from "@sentry/browser";
 import {Vue as VueIntegration} from "@sentry/integrations/dist/vue";
+import {SettingsState} from "@/plugins/store/settings";
 
 
 Vue.config.productionTip = false;
 
-// Fetch settings because we can only initialize sentry before Vue      TODO Improve because loading delay
-fetch(new Request('/settings.json', {
-    mode: 'same-origin',
-}))
-    .then(response => response.json())
-    .then(response => {
-        if (response.sentry_dsn !== '')
-            Sentry.init({
-                dsn: response.sentry_dsn,
-                environment: response.environment,
-                integrations: [new VueIntegration({
-                    // @ts-ignore
-                    Vue: Vue,
-                    attachProps: true,
-                    logErrors: true,
-                })],
-            });
+// @ts-ignore
+// global settings are loaded via a separate script tag so that they can be runtime configurable
+const settings: SettingsState = window.L2GO_SETTINGS;
 
-        new Vue({
-            router,
-            store,
-            vuetify,
-            render: (h) => h(App),
-        }).$mount('#app');
+if (settings.sentry_dsn != null && settings.sentry_dsn !== '')
+    Sentry.init({
+        dsn: settings.sentry_dsn,
+        environment: settings.environment,
+        integrations: [new VueIntegration({
+            // @ts-ignore
+            Vue: Vue,
+            attachProps: true,
+            logErrors: true,
+        })],
     });
+
+new Vue({
+    router,
+    store,
+    vuetify,
+    render: (h) => h(App),
+}).$mount('#app');

--- a/lecture2gether-vue/src/plugins/store/settings.ts
+++ b/lecture2gether-vue/src/plugins/store/settings.ts
@@ -1,4 +1,3 @@
-import Vue from 'vue';
 import { Module } from 'vuex';
 
 
@@ -11,24 +10,6 @@ export class SettingsState {
 
 
 export const settingsModule: Module<SettingsState, any> = {
-    state: () => new SettingsState(),
-
-    mutations: {
-        updateSettings: (state, payload) => {
-            for (const p of Object.keys(state)) {
-                if (payload[p] !== undefined) {
-                    Vue.set(state, p, payload[p]);
-                }
-            }
-        },
-    },
-
-    actions: {
-        fetchSettings: async (context) => {
-            const response = await fetch(new Request('/settings.json', {
-                mode: 'same-origin',
-            }));
-            context.commit('updateSettings', await response.json());
-        },
-    },
+    // @ts-ignore
+    state: () => window.L2GO_SETTINGS,
 };


### PR DESCRIPTION
This was done by refactoring the frontends runtime settings to not be a
JSON file which had to be loaded from code but instead be javascript
code itself. By doing so, the browser can optimize loading times more
efficiently. This also removes the need for us to fetch the settings
twice (once before application init and once after).

The changes can be tested on [staging.lecture2gether.eu](https://staging.lecture2gether.eu)