### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ GOOGLE\_DRIVE\_API\_KEY_FRONTEND | *empty* | Google Drive API key, used to acces
 SENTRY\_DSN | *empty* | Sentry connection [DSN](https://docs.sentry.io/error-reporting/configuration/?platform=python#dsn)
 SENTRY\_ENV | default | Sentry [environment](https://docs.sentry.io/error-reporting/configuration/?platform=python#environment)
 
-[1] This key is **publicly readable**, restrict its usage to the used website (e.g. https://lecture2gether.eu or equivalent IP address) and Google Drive in the Google API console.
+[1] This key is **publicly readable**, restrict its usage to the used website (e.g. https://lecture2gether.eu) and Google Drive in the Google API console.
 
 The frontend is configured via a `settings.js` file which should be reachable on a
 request to `/settings.js` from the running browser application.


### PR DESCRIPTION
Fixes the sentence that states that the IP of the frontend key should be restricted. This is wrong. For the frontend key, only a domain restriction is feasible. The IP restriction can be done to restrict the key to a certain backend server. This makes no sense at this point because the only IP that can be used for the frontend key is the IP of the user and that makes no sense.
An IP restriction could be applied to the backend server but it is secret anyway and not included in this warning.