### PR TITLE
Fix API root

### DIFF
--- a/lecture2gether-vue/public/settings.js
+++ b/lecture2gether-vue/public/settings.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 window.L2GO_SETTINGS = {
-    apiRoot: 'http://localhost:5000/api',
-    socketioHost: 'http://localhost:5000',
+    apiRoot: 'http://localhost:5000/api/',
+    socketioHost: 'http://localhost:5000/',
     environment: 'dev',
 };


### PR DESCRIPTION
I realized that the frontend was not able to connect to the metadata API on my local instance because of a missing `/` in the URL.
The requested URL requested was `http://localhost:5000/apimetadata` instead of `http://localhost:5000/api/metadata`. 
These commits should fix the issue.